### PR TITLE
Wait for cluster being successfully updated before updating cluster

### DIFF
--- a/gcp-gke-control-plane-auth-networks-updater/index.js
+++ b/gcp-gke-control-plane-auth-networks-updater/index.js
@@ -33,6 +33,8 @@ async function updateCluster(client, projectId, location, clusterName, mode, des
 
   logMasterAuthorizedNetworks(cluster.masterAuthorizedNetworksConfig.cidrBlocks)
 
+  waitForOperation(client, `projects/${ projectId }/locations/${ location }/operations/${ updateOp.name }`, 20)
+
   const [updateOp] = await client.updateCluster({
     name: clusterName,
     update: {


### PR DESCRIPTION
This PR is for #75.

Background: In the post action of _gcp-gke-control-plane-auth-networks-updater_, the cluster is trying to get updated while it is still in operation. There is a _waitForOperation_ afterwards but not before.

I added it also before _updateCluster_ to allow the last update to settle before trying again.
