### PR TITLE
precommit_fix: precommit mdformat verion bump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: shfmt
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 82f84976fc57d5ae61cbf2d457a26a89d4b4eef4  # frozen: 0.7.16
+    rev: 6c1288142f351100fb24babd44aedd20e1599e99 # frozen: 0.7.17
     hooks:
       - id: mdformat
         # Optionally add plugins


### PR DESCRIPTION
Mdformat pre-commit has to be updated at least to 0.7.17.
Change log from out current to 0.7.17: 
https://github.com/hukkin/mdformat/compare/0.7.16...0.7.17#diff-620c5f430705990ed868d906823aa75f4d1d4c8222d4737e00676c800d41d6d6
## 0.7.17

- Added
  - Do not update mtime if formatting result is identical to the file.
    Thank you, [Pierre Augier](https://github.com/paugier), for the issue and the PR.
- Fixed
  - An error on empty paragraph (Unicode space only).
    Thank you, [Nico Schlömer](https://github.com/nschloe), for the issue.
  - File write fails if no permissions to write to the directory.
    Fixed by removing atomic writes.
    Thank you, [Guy Kisel](https://github.com/guykisel), for the issue.
  - File permissions change on rewrite.
    Thank you, [Keiichi Watanabe](https://github.com/keiichiw), for the issue.
- Removed
  - Python 3.7 support
  
  Python support was switched to 3.8 which fixes our issue.