### PR TITLE
aotw-07.08 froze dependencies version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
       - id: mdformat
         # Optionally add plugins
         additional_dependencies:
-          - mdformat-gfm
+          - mdformat-gfm==0.3.5
           - mdformat-tables
           - mdformat-toc
+          - markdown-it-py==2.2.0
+          - mdit-py-plugins==0.3.5


### PR DESCRIPTION
aotw-07.08 
one of mdformat dependencies new versions require linkify dat return errors in our environment
froze that to an older version